### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,16 @@
 # Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/schneedotdev/til/compare/v0.1.0...v0.1.1) - 2024-08-16
+
+### Added
+- change name of binary
+
+### Docs
+- updated command comments
+# Changelog

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "today-i-learned"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "today-i-learned"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Brian Schnee"]
 license = "Unlicense OR MIT"


### PR DESCRIPTION
## 🤖 New release
* `today-i-learned`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/schneedotdev/til/compare/v0.1.0...v0.1.1) - 2024-08-16

### Added
- change name of binary

### Docs
- updated command comments
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).