### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/schneedotdev/til/compare/v0.1.1...v0.1.2) - 2024-08-17
+
+### Added
+- file-related errors
+
+### Fixed
+- remove main_tests
+
+### Refactor
+- relocate match within fmt fn
+
 ## [0.1.1](https://github.com/schneedotdev/til/compare/v0.1.0...v0.1.1) - 2024-08-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "today-i-learned"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "today-i-learned"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Brian Schnee"]
 license = "Unlicense OR MIT"


### PR DESCRIPTION
## 🤖 New release
* `today-i-learned`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/schneedotdev/til/compare/v0.1.1...v0.1.2) - 2024-08-17

### Added
- file-related errors

### Fixed
- remove main_tests

### Refactor
- relocate match within fmt fn
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).