### PR TITLE
[DEV] Add two new error types and refactor code using expect

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, path::PathBuf};
 
 type Message = String;
 type Directory = String;
@@ -9,6 +9,8 @@ pub(crate) enum Error {
     CannotFindDir(Directory),
     CannotCreateDir(Directory),
     CannotProcessArgs,
+    CannotOpenOrCreatePath(PathBuf),
+    CannotWriteToFile(PathBuf),
     Custom(Message),
     #[default]
     Default,
@@ -27,6 +29,12 @@ impl Display for Error {
                 f.write_fmt(format_args!("cannot create {} directory", dir))
             }
             Error::CannotProcessArgs => f.write_str("cannot process command-line arguments"),
+            Error::CannotOpenOrCreatePath(path) => {
+                f.write_fmt(format_args!("cannot open or create {}", path.display()))
+            }
+            Error::CannotWriteToFile(file) => {
+                f.write_fmt(format_args!("cannot write to {}", file.display()))
+            }
             Error::Custom(msg) => f.write_str(msg),
             Error::Default => f.write_str("something wrong happened"),
         }
@@ -64,6 +72,14 @@ mod tests {
             (
                 Error::CannotProcessArgs,
                 "cannot process command-line arguments",
+            ),
+            (
+                Error::CannotOpenOrCreatePath("src/test".into()),
+                "cannot open or create src/test",
+            ),
+            (
+                Error::CannotWriteToFile("src/test".into()),
+                "cannot write to src/test",
             ),
             ("custom message".into(), "custom message"),
             (Error::default(), "something wrong happened"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 mod error;
 
 use std::{
-    fs::{self, OpenOptions},
-    io::Write,
-    path::{Path, PathBuf},
+    fs::{self, OpenOptions}, io::Write, os::unix::fs::MetadataExt, path::{Path, PathBuf}
 };
 
 use chrono::{Datelike, Local};
@@ -53,13 +51,12 @@ impl Entry {
         let mut file = OpenOptions::new()
             .append(true)
             .create(true)
-            .open(path)
-            .expect("cannot open or create file");
+            .open(&path)
+            .map_err(|_| Error::CannotOpenOrCreatePath(path.clone()))?;
+
 
         file.write_all(format!("- {}\n", self.message).as_bytes())
-            .expect("cannot write to file");
-
-        Ok(())
+            .map_err(|_| Error::CannotWriteToFile(path.clone()))
     }
 
     fn build_path(&self) -> error::Result<PathBuf> {


### PR DESCRIPTION
## Error Enum
- Added `CannotOpenOrCreatePath(PathBuf)`
- Added `CannotWriteToFile(PathBuf)`

## impl Display block
- Exhaustive additions for `fmt` function

## Tests
- Verify `fmt` yields proper messages