### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "today-i-learned"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "today-i-learned"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Brian Schnee"]
 license = "Unlicense OR MIT"


### PR DESCRIPTION
## 🤖 New release
* `today-i-learned`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/schneedotdev/til/compare/v0.1.1...v0.1.2) - 2024-08-17

### Added
- file-related errors

### Fixed
- remove main_tests

### Refactor
- relocate match within fmt fn
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).