### PR TITLE
`til add` and note entry metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +326,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +398,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ path = "src/main.rs"
 chrono = "0.4.38"
 clap = { version = "4.5.14", features = ["derive"] }
 dirs = "5.0.1"
+regex = "1.10.6"
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 til is a command-line application designed to help you keep track of the important sh%t you want to remember. Whether it's a key insight from your work, a useful programming trick, or a valuable life lesson, this app helps you store and retrieve your notes in a friendly manner.
 
 ## Current Features
-* Store notes by passing a message and an optional title.
-* Retrieve your notes by searching a date (MM-DD-YYYY) or title.
+
+- Store notes by passing a message and an optional title.
+- Retrieve your notes by searching a date (MM-DD-YYYY) or title.
 
 ## Installation
 
@@ -18,12 +19,12 @@ _today-i-learned on [crates.io](https://crates.io/crates/today-i-learned)_
 
 ## Usage
 
-### That
+### Add
 
-To store a note, use the `that` command with a message and an optional title:
+To store a note, use the `add` command, passing a message and _optional_ tags (comma-separated with no spaces):
 
 ```
-til that --message "Your note message" --title "Optional title"
+til add "til is build with clap, a powerful command-line argument parser" --tags "rust,clap,crates"
 ```
 
 ### On

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ pub(crate) enum Error {
     CannotProcessArgs,
     CannotOpenOrCreatePath(PathBuf),
     CannotWriteToFile(PathBuf),
+    CannotReadFile(PathBuf),
     Custom(Message),
     #[default]
     Default,
@@ -34,6 +35,9 @@ impl Display for Error {
             }
             Error::CannotWriteToFile(file) => {
                 f.write_fmt(format_args!("cannot write to {}", file.display()))
+            }
+            Error::CannotReadFile(file) => {
+                f.write_fmt(format_args!("cannot read file {}", file.display()))
             }
             Error::Custom(msg) => f.write_str(msg),
             Error::Default => f.write_str("something wrong happened"),
@@ -80,6 +84,10 @@ mod tests {
             (
                 Error::CannotWriteToFile("src/test".into()),
                 "cannot write to src/test",
+            ),
+            (
+                Error::CannotReadFile("src/test".into()),
+                "cannot read file src/test",
             ),
             ("custom message".into(), "custom message"),
             (Error::default(), "something wrong happened"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,10 +87,7 @@ mod tests {
                 Error::CannotWriteToFile("src/test".into()),
                 "cannot write to src/test",
             ),
-            (
-                Error::CannotParseMetaData,
-                "cannot parse metadata",
-            ),
+            (Error::CannotParseMetaData, "cannot parse metadata"),
             (
                 Error::CannotReadFile("src/test".into()),
                 "cannot read file src/test",

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ pub(crate) enum Error {
     CannotProcessArgs,
     CannotOpenOrCreatePath(PathBuf),
     CannotWriteToFile(PathBuf),
+    CannotParseMetaData,
     CannotReadFile(PathBuf),
     Custom(Message),
     #[default]
@@ -39,6 +40,7 @@ impl Display for Error {
             Error::CannotReadFile(file) => {
                 f.write_fmt(format_args!("cannot read file {}", file.display()))
             }
+            Error::CannotParseMetaData => f.write_str("cannot parse metadata"),
             Error::Custom(msg) => f.write_str(msg),
             Error::Default => f.write_str("something wrong happened"),
         }
@@ -84,6 +86,10 @@ mod tests {
             (
                 Error::CannotWriteToFile("src/test".into()),
                 "cannot write to src/test",
+            ),
+            (
+                Error::CannotParseMetaData,
+                "cannot parse metadata",
             ),
             (
                 Error::CannotReadFile("src/test".into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// stores a note entry
-    That {
+    /// Add a new note entry
+    Add {
         #[clap(flatten)]
         entry: Entry,
     },
@@ -39,8 +39,7 @@ enum Command {
 
 #[derive(Args, Debug)]
 struct Entry {
-    #[clap(short, long)]
-    message: String,
+    content: String,
 
     #[clap(short, long, default_value = "default")]
     title: String,
@@ -56,7 +55,7 @@ impl Entry {
             .open(&path)
             .map_err(|_| Error::CannotOpenOrCreatePath(path.clone()))?;
 
-        file.write_all(format!("- {}\n", self.message).as_bytes())
+        file.write_all(format!("- {}\n", self.content).as_bytes())
             .map_err(|_| Error::CannotWriteToFile(path.clone()))
     }
 
@@ -102,7 +101,7 @@ fn main() -> error::Result<()> {
     match args.command {
         Some(command) => {
             match command {
-                Command::That { entry } => entry.write()?,
+                Command::Add { entry } => entry.write()?,
                 Command::On { search_params } => Entry::retrieve_from(search_params),
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,9 +42,6 @@ enum Command {
 struct Entry {
     content: String,
 
-    #[clap(short, long, default_value = "default")]
-    title: String,
-
     #[clap(long, use_value_delimiter = true, default_value = "")]
     tags: Vec<String>,
 }
@@ -81,7 +78,7 @@ impl Entry {
 
         let root_dir = find_root_dir().ok_or(Error::CannotFindDir("root".to_owned()))?;
         let path = {
-            let mut path = Path::new(&root_dir).join(&date).join(&self.title);
+            let mut path = Path::new(&root_dir).join(&date).join("default");
             path.set_extension("md");
             path
         };
@@ -124,12 +121,11 @@ impl Entry {
     fn generate_meta(&self) -> String {
         format!(
             r#"---
-title: "{}"
+title: "default"
 tags: [{}]
 ---
 
 "#,
-            self.title,
             self.tags.join(", ")
         )
     }


### PR DESCRIPTION
### Changes

- Replaced `that` command with `add`
- Removed `--message` flag
- Added optional `--tags` flag that accepts command-separated values (no spaces) to be added to the metadata of a note entry
- Generate metadata when a new entry is created using `generate_meta`
- `update_meta` is used when new tags are passed to the program. They are appending to the tags section of a note's metadata:

```
---
title: "example"
tags: ["tag1", "tag2"]
---
```

- Update `README.md` with command information
- Add detailed comments to new functions with function usage.