### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/schneedotdev/til/compare/v0.1.2...v0.1.3) - 2024-08-17
+
+### Added
+- update_meta function used to update any new tags provided by CL
+- new error variant for parsing metadata
+- added regex crate
+- generate metadata for note entries
+- new command `add` replacing `that`
+
+### Docs
+- information on `add` command
+
+### Fixed
+- formatting in error.rs
+
+### Removed
+- title arg has been removed
+
 ## [0.1.2](https://github.com/schneedotdev/til/compare/v0.1.1...v0.1.2) - 2024-08-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "today-i-learned"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "today-i-learned"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Brian Schnee"]
 license = "Unlicense OR MIT"


### PR DESCRIPTION
## 🤖 New release
* `today-i-learned`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/schneedotdev/til/compare/v0.1.2...v0.1.3) - 2024-08-17

### Added
- update_meta function used to update any new tags provided by CL
- new error variant for parsing metadata
- added regex crate
- generate metadata for note entries
- new command `add` replacing `that`

### Docs
- information on `add` command

### Fixed
- formatting in error.rs

### Removed
- title arg has been removed
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).