### PR TITLE
New search by date command - `til search --date "MM-DD-YYYY"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ til add "til is build with clap, a powerful command-line argument parser" --tags
 
 ### Search
 
-To search for a note, use the `search` command, specifying a date or a range of dates ("MM-DD-YYYY").
+To search for a note, use the `search` command, specifying a date <!--or a range of dates -->("MM-DD-YYYY").
 
 #### Date
 
@@ -39,13 +39,13 @@ Search for a note from a specific date:
 til search --date "8-18-2024"
 ```
 
-#### Range
+<!-- #### Range
 
 Search for a note within a range:
 
 ```
 til search --from "8-16-2024" --to "8-18-2024"
-```
+``` -->
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,24 @@ To store a note, use the `add` command, passing a message and _optional_ tags (c
 til add "til is build with clap, a powerful command-line argument parser" --tags "rust,clap,crates"
 ```
 
-### On
+### Search
 
-To retrieve a note, use the `on` command with the date and title parameters:
+To search for a note, use the `search` command, specifying a date or a range of dates ("MM-DD-YYYY").
+
+#### Date
+
+Search for a note from a specific date:
 
 ```
-til on --date "MM-DD-YYYY" --title "Title"
+til search --date "8-18-2024"
+```
+
+#### Range
+
+Search for a note within a range:
+
+```
+til search --from "8-16-2024" --to "8-18-2024"
 ```
 
 ## Configuration

--- a/justfile
+++ b/justfile
@@ -1,6 +1,10 @@
 alias c := create
 alias f := format
 
+# watch and install
+watch:
+    cargo watch -q -c -x "install --path ."
+
 # create a til entry
 create:
     cargo run -q -- that -m "new bullet point" -t "example"

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,0 +1,163 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use crate::{find_root_dir, Error};
+use chrono::{Datelike, Local};
+use clap::Args;
+use regex::Regex;
+
+#[derive(Args, Debug)]
+pub struct Entry {
+    content: String,
+
+    #[clap(long, use_value_delimiter = true, default_value = "")]
+    tags: Vec<String>,
+}
+
+impl Entry {
+    pub fn write(&self) -> crate::error::Result<()> {
+        let path = self.build_path().map_err(|_| Error::CannotBuildPath)?;
+
+        let mut file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&path)
+            .map_err(|_| Error::CannotOpenOrCreatePath(path.clone()))?;
+
+        let file_size = file
+            .metadata()
+            .map_err(|_| Error::CannotReadFile(path.clone()))?
+            .len();
+
+        if file_size == 0 {
+            file.write_all(self.generate_meta().as_bytes())
+                .map_err(|_| Error::CannotWriteToFile(path.clone()))?;
+        } else if !self.tags.is_empty() {
+            self.update_meta(&path)?;
+        }
+
+        file.write_all(format!("- {}\n", self.content).as_bytes())
+            .map_err(|_| Error::CannotWriteToFile(path.clone()))
+    }
+
+    fn build_path(&self) -> crate::error::Result<PathBuf> {
+        let time = Local::now();
+        let date = format!("{:02}-{:02}-{}", time.month(), time.day(), time.year());
+
+        let root_dir = find_root_dir().ok_or(Error::CannotFindDir("root".to_owned()))?;
+        let path = {
+            let mut path = Path::new(&root_dir).join(&date).join("default");
+            path.set_extension("md");
+            path
+        };
+
+        let directory = path
+            .parent()
+            .ok_or(Error::CannotFindDir("parent".to_owned()))?;
+
+        if !directory.exists() {
+            fs::create_dir_all(directory)
+                .map_err(|_| Error::CannotCreateDir(path.display().to_string()))?;
+        }
+
+        Ok(path)
+    }
+
+    /// Generates a metadata block for a note entry.
+    ///
+    /// This function will create a front matter block which includes the
+    /// title and tags of the note.
+    ///
+    /// ## Returns
+    ///
+    /// Returns a `String` containing the formatted metadata block.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// let entry = Entry {
+    ///     title: "Example Title".to_string(),
+    ///     tags: vec!["tag1".to_string(), "tag2".to_string()],
+    /// };
+    /// let meta = entry.generate_meta();
+    /// assert_eq!(meta, r#"---
+    /// title: "Example Title"
+    /// tags: [tag1, tag2]
+    /// ---
+    /// "#);
+    /// ```
+    fn generate_meta(&self) -> String {
+        format!(
+            r#"---
+    title: "default"
+    tags: [{}]
+    ---
+    
+    "#,
+            self.tags.join(", ")
+        )
+    }
+
+    /// Updates the metadata block for a note entry.
+    ///
+    /// This function reads the contents of a note entry, parses the metadata,
+    /// and updates the "tags" field with any new tags provided in the `Entry`. Tags
+    /// already present are not duplicated. The function assumes the metadata is at the
+    /// beginning of the file, separated from the content by a `---` delimiter. If the
+    /// metadata is missing or cannot be parsed, an error is returned.
+    ///
+    /// ## Arguments
+    ///
+    /// * `path` - A reference to the path of the file where the metadata should be updated.
+    ///
+    /// ## Returns
+    ///
+    /// Returns a `Result` indicating success (`Ok(())`) or failure (`Error`).
+    ///
+    /// ## Errors
+    ///
+    /// * `Error::CannotOpenOrCreatePath` - If the file cannot be opened.
+    /// * `Error::CannotReadFile` - If the file cannot be read.
+    /// * `Error::CannotParseMetaData` - If the metadata cannot be parsed.
+    /// * `Error::CannotWriteToFile` - If the updated contents cannot be written back to the file.
+    fn update_meta(&self, path: &PathBuf) -> crate::error::Result<()> {
+        let mut contents =
+            fs::read_to_string(&path).map_err(|_| Error::CannotReadFile(path.clone()))?;
+
+        let meta = contents
+            .split("\n---\n")
+            .next()
+            .ok_or(Error::CannotParseMetaData)?;
+
+        let tags_regex =
+            Regex::new(r"(?m)^tags:\s*\[(.*?)\]$").map_err(|_| Error::CannotParseMetaData)?;
+        let mut new_tags = self.tags.clone();
+
+        if let Some(captures) = tags_regex.captures(meta) {
+            let existing_tags: Vec<String> = captures[1]
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .collect();
+
+            new_tags.retain(|tag| !existing_tags.contains(tag));
+
+            if !new_tags.is_empty() {
+                let updated_tags = existing_tags
+                    .into_iter()
+                    .chain(new_tags)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                contents = contents.replace(&captures[0], &format!("tags: [{}]", updated_tags));
+            }
+        } else {
+            return Err(Error::CannotParseMetaData);
+        }
+
+        fs::write(&path, contents).map_err(|_| Error::CannotWriteToFile(path.clone()))?;
+
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub(crate) enum Error {
     CannotWriteToFile(PathBuf),
     CannotParseMetaData,
     CannotReadFile(PathBuf),
+    InvalidDateFormat,
     Custom(Message),
     #[default]
     Default,
@@ -41,6 +42,9 @@ impl Display for Error {
                 f.write_fmt(format_args!("cannot read file {}", file.display()))
             }
             Error::CannotParseMetaData => f.write_str("cannot parse metadata"),
+            Error::InvalidDateFormat => {
+                f.write_str("cannot parse date format, must use format MM-DD-YYYY")
+            }
             Error::Custom(msg) => f.write_str(msg),
             Error::Default => f.write_str("something wrong happened"),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ type Message = String;
 type Directory = String;
 
 #[derive(Debug, Default)]
-pub(crate) enum Error {
+pub enum Error {
     CannotBuildPath,
     CannotFindDir(Directory),
     CannotCreateDir(Directory),

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,8 +206,27 @@ tags: [{}]
         Ok(())
     }
 
-    fn retrieve_from(_params: SearchParams) {
-        todo!()
+    fn find_by_date(date: String) -> Option<String> {
+        let root_dir = find_root_dir()?;
+
+        let path = {
+            let mut path = Path::new(&root_dir).join(&date).join("default");
+            path.set_extension("md");
+            path
+        };
+
+        let directory = path
+            .parent()?;
+
+        if !directory.exists() {
+            return None;
+        }
+
+        fs::read_to_string(path).ok()
+    }
+
+    fn find_by_range(from: String, to: String) {
+        println!("find_by_range: {} {}", from, to);
     }
 }
 
@@ -227,7 +246,13 @@ fn main() -> error::Result<()> {
 
                         std::process::exit(1);
                     } else {
-                        Entry::retrieve_from(params);
+                        let mut entry = String::default();
+                        if let Some(date) = params.date {
+                            entry = Entry::find_by_date(date).unwrap();
+                        } else if let (Some(_from), Some(_to)) = (params.from, params.to) {
+                            
+                        }
+                        println!("{}", entry.trim())
                     }
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,13 @@
+mod entry;
 mod error;
+mod search;
 
-use std::{
-    fs::{self, OpenOptions},
-    io::Write,
-    path::{Path, PathBuf},
-};
-
-use chrono::{Datelike, Local};
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
+use entry::Entry;
 use error::Error;
 use regex::Regex;
+use search::Search;
+use std::path::{Path, PathBuf};
 
 const PATH_FROM_ROOT: &str = ".til/notes";
 
@@ -34,199 +32,8 @@ enum Command {
     /// Search for a note by an exact date or within a date range
     Search {
         #[clap(flatten)]
-        params: SearchParams,
+        search: Search,
     },
-}
-
-#[derive(Args, Debug)]
-
-struct SearchParams {
-    /// Specify an exact date ("MM-DD-YYY")
-    #[arg(long, group("search"))]
-    date: Option<String>,
-
-    /// Specify the start of a date range, used with "--to" ("MM-DD-YYYY")
-    #[arg(long, group("search"), requires = "to")]
-    from: Option<String>,
-
-    /// Specify the end of a date range, used with "--from" ("MM-DD-YYYY")
-    #[arg(long, requires = "from")]
-    to: Option<String>,
-}
-
-#[derive(Args, Debug)]
-struct Entry {
-    content: String,
-
-    #[clap(long, use_value_delimiter = true, default_value = "")]
-    tags: Vec<String>,
-}
-
-impl Entry {
-    fn write(&self) -> error::Result<()> {
-        let path = self.build_path().map_err(|_| Error::CannotBuildPath)?;
-
-        let mut file = OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(&path)
-            .map_err(|_| Error::CannotOpenOrCreatePath(path.clone()))?;
-
-        let file_size = file
-            .metadata()
-            .map_err(|_| Error::CannotReadFile(path.clone()))?
-            .len();
-
-        if file_size == 0 {
-            file.write_all(self.generate_meta().as_bytes())
-                .map_err(|_| Error::CannotWriteToFile(path.clone()))?;
-        } else if !self.tags.is_empty() {
-            self.update_meta(&path)?;
-        }
-
-        file.write_all(format!("- {}\n", self.content).as_bytes())
-            .map_err(|_| Error::CannotWriteToFile(path.clone()))
-    }
-
-    fn build_path(&self) -> error::Result<PathBuf> {
-        let time = Local::now();
-        let date = format!("{:02}-{:02}-{}", time.month(), time.day(), time.year());
-
-        let root_dir = find_root_dir().ok_or(Error::CannotFindDir("root".to_owned()))?;
-        let path = {
-            let mut path = Path::new(&root_dir).join(&date).join("default");
-            path.set_extension("md");
-            path
-        };
-
-        let directory = path
-            .parent()
-            .ok_or(Error::CannotFindDir("parent".to_owned()))?;
-
-        if !directory.exists() {
-            fs::create_dir_all(directory)
-                .map_err(|_| Error::CannotCreateDir(path.display().to_string()))?;
-        }
-
-        Ok(path)
-    }
-
-    /// Generates a metadata block for a note entry.
-    ///
-    /// This function will create a front matter block which includes the
-    /// title and tags of the note.
-    ///
-    /// ## Returns
-    ///
-    /// Returns a `String` containing the formatted metadata block.
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// let entry = Entry {
-    ///     title: "Example Title".to_string(),
-    ///     tags: vec!["tag1".to_string(), "tag2".to_string()],
-    /// };
-    /// let meta = entry.generate_meta();
-    /// assert_eq!(meta, r#"---
-    /// title: "Example Title"
-    /// tags: [tag1, tag2]
-    /// ---
-    /// "#);
-    /// ```
-    fn generate_meta(&self) -> String {
-        format!(
-            r#"---
-title: "default"
-tags: [{}]
----
-
-"#,
-            self.tags.join(", ")
-        )
-    }
-
-    /// Updates the metadata block for a note entry.
-    ///
-    /// This function reads the contents of a note entry, parses the metadata,
-    /// and updates the "tags" field with any new tags provided in the `Entry`. Tags
-    /// already present are not duplicated. The function assumes the metadata is at the
-    /// beginning of the file, separated from the content by a `---` delimiter. If the
-    /// metadata is missing or cannot be parsed, an error is returned.
-    ///
-    /// ## Arguments
-    ///
-    /// * `path` - A reference to the path of the file where the metadata should be updated.
-    ///
-    /// ## Returns
-    ///
-    /// Returns a `Result` indicating success (`Ok(())`) or failure (`Error`).
-    ///
-    /// ## Errors
-    ///
-    /// * `Error::CannotOpenOrCreatePath` - If the file cannot be opened.
-    /// * `Error::CannotReadFile` - If the file cannot be read.
-    /// * `Error::CannotParseMetaData` - If the metadata cannot be parsed.
-    /// * `Error::CannotWriteToFile` - If the updated contents cannot be written back to the file.
-    fn update_meta(&self, path: &PathBuf) -> error::Result<()> {
-        let mut contents =
-            fs::read_to_string(&path).map_err(|_| Error::CannotReadFile(path.clone()))?;
-
-        let meta = contents
-            .split("\n---\n")
-            .next()
-            .ok_or(Error::CannotParseMetaData)?;
-
-        let tags_regex =
-            Regex::new(r"(?m)^tags:\s*\[(.*?)\]$").map_err(|_| Error::CannotParseMetaData)?;
-        let mut new_tags = self.tags.clone();
-
-        if let Some(captures) = tags_regex.captures(meta) {
-            let existing_tags: Vec<String> = captures[1]
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .collect();
-
-            new_tags.retain(|tag| !existing_tags.contains(tag));
-
-            if !new_tags.is_empty() {
-                let updated_tags = existing_tags
-                    .into_iter()
-                    .chain(new_tags)
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                contents = contents.replace(&captures[0], &format!("tags: [{}]", updated_tags));
-            }
-        } else {
-            return Err(Error::CannotParseMetaData);
-        }
-
-        fs::write(&path, contents).map_err(|_| Error::CannotWriteToFile(path.clone()))?;
-
-        Ok(())
-    }
-
-    fn find_by_date(date: String) -> Option<String> {
-        let root_dir = find_root_dir()?;
-
-        let path = {
-            let mut path = Path::new(&root_dir).join(&date).join("default");
-            path.set_extension("md");
-            path
-        };
-
-        let directory = path.parent()?;
-
-        if !directory.exists() {
-            return None;
-        }
-
-        fs::read_to_string(path).ok()
-    }
-
-    fn find_by_range(from: String, to: String) {
-        println!("find_by_range: {} {}", from, to);
-    }
 }
 
 fn main() -> error::Result<()> {
@@ -236,9 +43,9 @@ fn main() -> error::Result<()> {
         Some(command) => {
             match command {
                 Command::Add { entry } => entry.write()?,
-                Command::Search { params } => {
+                Command::Search { search } => {
                     // handle exit case when "--date" is used with "--to"
-                    if params.date.is_some() && params.to.is_some() {
+                    if search.date.is_some() && search.to.is_some() {
                         eprintln!(
                             "\x1b[1;31merror\x1b[0m: the argument '\x1b[33m--date <DATE>\x1b[0m' cannot be used with '\x1b[33m--to <TO>\x1b[0m'\n\n\x1b[4mUsage\x1b[0m: \x1b[1mtil search --date\x1b[0m <DATE>\n\nFor more information, try '\x1b[1m--help\x1b[0m'."
                         );
@@ -246,7 +53,7 @@ fn main() -> error::Result<()> {
                         std::process::exit(1);
                     } else {
                         let mut entry = String::default();
-                        if let Some(date) = params.date {
+                        if let Some(date) = search.date {
                             // must use MM-DD-YYYY for date argument
                             let re = Regex::new(r"^\d{1,2}-\d{1,2}-\d{4}$").unwrap();
                             if !re.is_match(&date) {
@@ -255,14 +62,14 @@ fn main() -> error::Result<()> {
                                 std::process::exit(1);
                             }
 
-                            entry = match Entry::find_by_date(date.clone()) {
+                            entry = match Search::find_by_date(date.clone()) {
                                 Some(contents) => contents,
                                 None => {
                                     eprintln!("no notes were found from {}", date);
                                     std::process::exit(1);
                                 }
                             };
-                        } else if let (Some(_from), Some(_to)) = (params.from, params.to) {
+                        } else if let (Some(_from), Some(_to)) = (search.from, search.to) {
                         }
                         println!("{}", entry.trim())
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,15 +44,6 @@ fn main() -> error::Result<()> {
             match command {
                 Command::Add { entry } => entry.write()?,
                 Command::Search { search } => {
-                    // early exit when "--date" is used with "--to"
-                    // if search.date.is_some() && search.to.is_some() {
-                    //     eprintln!(
-                    //         "\x1b[1;31merror\x1b[0m: the argument '\x1b[33m--date <DATE>\x1b[0m' cannot be used with '\x1b[33m--to <TO>\x1b[0m'\n\n\x1b[4mUsage\x1b[0m: \x1b[1mtil search --date\x1b[0m <DATE>\n\nFor more information, try '\x1b[1m--help\x1b[0m'."
-                    //     );
-
-                    //     std::process::exit(1);
-                    // }
-
                     let mut entry = String::default();
                     if let Some(date) = search.date {
                         // must use MM-DD-YYYY for date argument
@@ -71,8 +62,6 @@ fn main() -> error::Result<()> {
                             }
                         };
                     }
-                    // } else if let (Some(_from), Some(_to)) = (search.from, search.to) {
-                    // }
                     println!("{}", entry.trim())
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,9 +32,9 @@ enum Command {
         entry: Entry,
     },
     /// recalls a note entry from a specific date
-    On {
+    Search {
         #[clap(flatten)]
-        search_params: SearchParams,
+        params: SearchParams,
     },
 }
 
@@ -190,17 +190,18 @@ tags: [{}]
         Ok(())
     }
 
-    fn retrieve_from(_search_params: SearchParams) {
+    fn retrieve_from(_params: SearchParams) {
         todo!()
     }
 }
 
 #[derive(Args, Debug)]
+#[group(required = true, multiple = false)]
 struct SearchParams {
-    #[arg(short, long, default_value = "")]
+    #[clap(long)]
     date: Option<String>,
-    #[arg(short, long, default_value = "")]
-    title: Option<String>,
+    #[clap(long)]
+    from: Option<String>,
 }
 
 fn main() -> error::Result<()> {
@@ -210,7 +211,7 @@ fn main() -> error::Result<()> {
         Some(command) => {
             match command {
                 Command::Add { entry } => entry.write()?,
-                Command::On { search_params } => Entry::retrieve_from(search_params),
+                Command::Search { params } => Entry::retrieve_from(params),
             };
 
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,35 +44,35 @@ fn main() -> error::Result<()> {
             match command {
                 Command::Add { entry } => entry.write()?,
                 Command::Search { search } => {
-                    // handle exit case when "--date" is used with "--to"
+                    // early exit when "--date" is used with "--to"
                     if search.date.is_some() && search.to.is_some() {
                         eprintln!(
                             "\x1b[1;31merror\x1b[0m: the argument '\x1b[33m--date <DATE>\x1b[0m' cannot be used with '\x1b[33m--to <TO>\x1b[0m'\n\n\x1b[4mUsage\x1b[0m: \x1b[1mtil search --date\x1b[0m <DATE>\n\nFor more information, try '\x1b[1m--help\x1b[0m'."
                         );
 
                         std::process::exit(1);
-                    } else {
-                        let mut entry = String::default();
-                        if let Some(date) = search.date {
-                            // must use MM-DD-YYYY for date argument
-                            let re = Regex::new(r"^\d{1,2}-\d{1,2}-\d{4}$").unwrap();
-                            if !re.is_match(&date) {
-                                let err = Error::InvalidDateFormat;
-                                eprintln!("{err}");
+                    }
+
+                    let mut entry = String::default();
+                    if let Some(date) = search.date {
+                        // must use MM-DD-YYYY for date argument
+                        let re = Regex::new(r"^\d{1,2}-\d{1,2}-\d{4}$").unwrap();
+                        if !re.is_match(&date) {
+                            let err = Error::InvalidDateFormat;
+                            eprintln!("{err}");
+                            std::process::exit(1);
+                        }
+
+                        entry = match Search::by_date(date.to_owned()) {
+                            Some(contents) => contents,
+                            None => {
+                                eprintln!("no notes were found from {}", date);
                                 std::process::exit(1);
                             }
-
-                            entry = match Search::by_date(date.to_owned()) {
-                                Some(contents) => contents,
-                                None => {
-                                    eprintln!("no notes were found from {}", date);
-                                    std::process::exit(1);
-                                }
-                            };
-                        } else if let (Some(_from), Some(_to)) = (search.from, search.to) {
-                        }
-                        println!("{}", entry.trim())
+                        };
+                    } else if let (Some(_from), Some(_to)) = (search.from, search.to) {
                     }
+                    println!("{}", entry.trim())
                 }
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> error::Result<()> {
                                 std::process::exit(1);
                             }
 
-                            entry = match Search::find_by_date(date.clone()) {
+                            entry = match Search::by_date(date.clone()) {
                                 Some(contents) => contents,
                                 None => {
                                     eprintln!("no notes were found from {}", date);

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ impl Entry {
 
     fn build_path(&self) -> error::Result<PathBuf> {
         let time = Local::now();
-        let date = format!("{}-{}-{}", time.month(), time.day(), time.year());
+        let date = format!("{:02}-{:02}-{}", time.month(), time.day(), time.year());
 
         let root_dir = find_root_dir().ok_or(Error::CannotFindDir("root".to_owned()))?;
         let path = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,8 +215,7 @@ tags: [{}]
             path
         };
 
-        let directory = path
-            .parent()?;
+        let directory = path.parent()?;
 
         if !directory.exists() {
             return None;
@@ -248,9 +247,22 @@ fn main() -> error::Result<()> {
                     } else {
                         let mut entry = String::default();
                         if let Some(date) = params.date {
-                            entry = Entry::find_by_date(date).unwrap();
+                            // must use MM-DD-YYYY for date argument
+                            let re = Regex::new(r"^\d{1,2}-\d{1,2}-\d{4}$").unwrap();
+                            if !re.is_match(&date) {
+                                let err = Error::InvalidDateFormat;
+                                eprintln!("{err}");
+                                std::process::exit(1);
+                            }
+
+                            entry = match Entry::find_by_date(date.clone()) {
+                                Some(contents) => contents,
+                                None => {
+                                    eprintln!("no notes were found from {}", date);
+                                    std::process::exit(1);
+                                }
+                            };
                         } else if let (Some(_from), Some(_to)) = (params.from, params.to) {
-                            
                         }
                         println!("{}", entry.trim())
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,13 +45,13 @@ fn main() -> error::Result<()> {
                 Command::Add { entry } => entry.write()?,
                 Command::Search { search } => {
                     // early exit when "--date" is used with "--to"
-                    if search.date.is_some() && search.to.is_some() {
-                        eprintln!(
-                            "\x1b[1;31merror\x1b[0m: the argument '\x1b[33m--date <DATE>\x1b[0m' cannot be used with '\x1b[33m--to <TO>\x1b[0m'\n\n\x1b[4mUsage\x1b[0m: \x1b[1mtil search --date\x1b[0m <DATE>\n\nFor more information, try '\x1b[1m--help\x1b[0m'."
-                        );
+                    // if search.date.is_some() && search.to.is_some() {
+                    //     eprintln!(
+                    //         "\x1b[1;31merror\x1b[0m: the argument '\x1b[33m--date <DATE>\x1b[0m' cannot be used with '\x1b[33m--to <TO>\x1b[0m'\n\n\x1b[4mUsage\x1b[0m: \x1b[1mtil search --date\x1b[0m <DATE>\n\nFor more information, try '\x1b[1m--help\x1b[0m'."
+                    //     );
 
-                        std::process::exit(1);
-                    }
+                    //     std::process::exit(1);
+                    // }
 
                     let mut entry = String::default();
                     if let Some(date) = search.date {
@@ -70,8 +70,9 @@ fn main() -> error::Result<()> {
                                 std::process::exit(1);
                             }
                         };
-                    } else if let (Some(_from), Some(_to)) = (search.from, search.to) {
                     }
+                    // } else if let (Some(_from), Some(_to)) = (search.from, search.to) {
+                    // }
                     println!("{}", entry.trim())
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> error::Result<()> {
                                 std::process::exit(1);
                             }
 
-                            entry = match Search::by_date(date.clone()) {
+                            entry = match Search::by_date(date.to_owned()) {
                                 Some(contents) => contents,
                                 None => {
                                     eprintln!("no notes were found from {}", date);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn find_root_dir() -> Option<PathBuf> {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "til", version = "0.1.0", about = "✨ 'today i learned' is used to keep track of the important sh%t you want to remember ✨", long_about = None, arg_required_else_help = true)]
+#[command(name = "til", version, about = "✨ 'today i learned' is used to keep track of the important sh%t you want to remember ✨", long_about = None, arg_required_else_help = true)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,0 +1,44 @@
+use std::{fs, path::Path};
+
+use clap::Args;
+
+use crate::find_root_dir;
+
+#[derive(Args, Debug)]
+pub struct Search {
+    /// Specify an exact date ("MM-DD-YYY")
+    #[clap(long, group("search"))]
+    pub date: Option<String>,
+
+    /// Specify the start of a date range, used with "--to" ("MM-DD-YYYY")
+    #[clap(long, group("search"), requires = "to")]
+    pub from: Option<String>,
+
+    /// Specify the end of a date range, used with "--from" ("MM-DD-YYYY")
+    #[clap(long, requires = "from")]
+    pub to: Option<String>,
+}
+
+impl Search {
+    pub fn find_by_date(date: String) -> Option<String> {
+        let root_dir = find_root_dir()?;
+
+        let path = {
+            let mut path = Path::new(&root_dir).join(&date).join("default");
+            path.set_extension("md");
+            path
+        };
+
+        let directory = path.parent()?;
+
+        if !directory.exists() {
+            return None;
+        }
+
+        fs::read_to_string(path).ok()
+    }
+
+    pub fn _find_by_range(from: String, to: String) {
+        println!("find_by_range: {} {}", from, to);
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -9,14 +9,6 @@ pub struct Search {
     /// Specify an exact date ("MM-DD-YYY")
     #[clap(long, group("search"))]
     pub date: Option<String>,
-
-    // Specify the start of a date range, used with "--to" ("MM-DD-YYYY")
-    // #[clap(long, group("search"), requires = "to")]
-    // pub from: Option<String>,
-
-    // Specify the end of a date range, used with "--from" ("MM-DD-YYYY")
-    // #[clap(long, requires = "from")]
-    // pub to: Option<String>,
 }
 
 impl Search {
@@ -37,8 +29,4 @@ impl Search {
 
         fs::read_to_string(path).ok()
     }
-
-    // pub fn _by_date_range(from: String, to: String) {
-    //     println!("find_by_range: {} {}", from, to);
-    // }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -10,13 +10,13 @@ pub struct Search {
     #[clap(long, group("search"))]
     pub date: Option<String>,
 
-    /// Specify the start of a date range, used with "--to" ("MM-DD-YYYY")
-    #[clap(long, group("search"), requires = "to")]
-    pub from: Option<String>,
+    // Specify the start of a date range, used with "--to" ("MM-DD-YYYY")
+    // #[clap(long, group("search"), requires = "to")]
+    // pub from: Option<String>,
 
-    /// Specify the end of a date range, used with "--from" ("MM-DD-YYYY")
-    #[clap(long, requires = "from")]
-    pub to: Option<String>,
+    // Specify the end of a date range, used with "--from" ("MM-DD-YYYY")
+    // #[clap(long, requires = "from")]
+    // pub to: Option<String>,
 }
 
 impl Search {
@@ -38,7 +38,7 @@ impl Search {
         fs::read_to_string(path).ok()
     }
 
-    pub fn _by_date_range(from: String, to: String) {
-        println!("find_by_range: {} {}", from, to);
-    }
+    // pub fn _by_date_range(from: String, to: String) {
+    //     println!("find_by_range: {} {}", from, to);
+    // }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -20,7 +20,7 @@ pub struct Search {
 }
 
 impl Search {
-    pub fn find_by_date(date: String) -> Option<String> {
+    pub fn by_date(date: String) -> Option<String> {
         let root_dir = find_root_dir()?;
 
         let path = {
@@ -38,7 +38,7 @@ impl Search {
         fs::read_to_string(path).ok()
     }
 
-    pub fn _find_by_range(from: String, to: String) {
+    pub fn _by_date_range(from: String, to: String) {
         println!("find_by_range: {} {}", from, to);
     }
 }


### PR DESCRIPTION
- Update README with `til search` usage.
- Separate Entry and Search into new modules.
- `just watch` command to compile the binary for direct usage.
- `InvalidDateFormat` error
- Change entity visibility/access (pub or priv)


Coming soon: `Search::by_date_range()`